### PR TITLE
Small edits before launch

### DIFF
--- a/resources/content/pages/donations/donations-en.md
+++ b/resources/content/pages/donations/donations-en.md
@@ -3,7 +3,7 @@ donations_title: en (English) donations page content
 donations_content:
   donations_page_title: Donations
   donations_page_content: |
-    If you or your organization are interested in providing support to the **Haskell Foundation** please contact us at *donations@haskell.foundation* to join the other supporters of the **Haskell Foundation**.
+    If you or your organization is interested in providing support to the **Haskell Foundation** please contact us at *donations@haskell.foundation* to join the other supporters of the **Haskell Foundation**.
 
     #### Supporting the **Haskell Foundation**
 
@@ -15,9 +15,9 @@ donations_content:
 
     #### Enterprise Support Tiers
 
-    Monad: $50K per year. All of the benefits of Functor and Applicative memberships, with the addition of a full interview for the **Haskell Foundation** blog, as well as having your logo prominently displayed on the HF website.
-    Applicative: $25K per year. Have your logo and story featured in the Supporter Spotlight on the website and newsletter, a medium-sized logo displayed on the HF website, and receive ongoing recognition on our social media pages.
-    Functor:  $10K per year. Receive ongoing acknowledgements on Social Media channels, and have a small logo displayed on the HF website.
+    * Monad: $50K per year. All of the benefits of Functor and Applicative memberships, with the addition of a full interview for the **Haskell Foundation** blog, as well as having your logo prominently displayed on the HF website.
+    * Applicative: $25K per year. Have your logo and story featured in the Supporter Spotlight on the website and newsletter, a medium-sized logo displayed on the HF website, and receive ongoing recognition on our social media pages.
+    * Functor:  $10K per year. Receive ongoing acknowledgements on Social Media channels, and have a small logo displayed on the HF website.
 
     #### In-Kind Support
     Non-financial contributions to HF are very welcome. As a volunteer-based organization, the **Haskell Foundation** needs volunteers who can work on software, documentation, promotion, and other tasks to support the HF affiliated projects and the Haskell community. Individuals who contribute their own time or on behalf of their company are the backbone of our organization. Please reach out to us at contact@haskell.foundation to learn more about how you can volunteer or offer in-kind support.

--- a/resources/content/pages/faq/faq-en.md
+++ b/resources/content/pages/faq/faq-en.md
@@ -9,18 +9,18 @@ faq_content:
 
     ### What projects is HF involved in?
 
-    The [Haskell Foundation Technical Agenda](https://docs.google.com/document/d/1RVth1orvC6_hPp7YX0zYR8iTzCDBtM4esHOdfIxqmrk) outlines the current technical work that the Haskell Foundation is prioritizing. The Haskell Foundation (HF) grants a new opportunity to invest in Haskell and increase its productivity. This technical agenda includes a list of projects that we expect the HF to cultivate and support, depending on resources. This list is meant to be suggestive, not definitive: as the HF continues to mature, we may find that other technical projects become more important than what is listed below. In particular, we expect the HF to support a function where we can collect feedback (encompassing instruments like surveys, interviews, and user studies), and then we hope to use that feedback to inform our technical priorities.
+    The [Haskell Foundation Technical Agenda](https://docs.google.com/document/d/1RVth1orvC6_hPp7YX0zYR8iTzCDBtM4esHOdfIxqmrk) outlines the current technical work that the Haskell Foundation is prioritizing. The HF grants a new opportunity to invest in Haskell and increase its productivity. This technical agenda includes a list of projects that we expect the HF to cultivate and support, depending on resources. 
 
     ### What is the relationship between HF and haskell.org?
 
-    The Haskell.org committee has voted to affiliate with the Haskell Foundation, however the haskell.org committee remains an independent 501-3 (c) nonprofit organization. The haskell.org committee will continue to operate the haskell.org website and provide resources for haskell infrastructure such as Hackage and the haskell mailing lists.
+    The Haskell.org committee has voted to affiliate with the Haskell Foundation; however, the haskell.org committee remains an independent 501-3 (c) nonprofit organization. The haskell.org committee will continue to operate the haskell.org website and provide resources for haskell infrastructure such as Hackage and the haskell mailing lists.
 
     ### Who’s involved?
 
-    The haskell foundation was founded by members of the haskell community, with help and input from existing haskell users, committees, and industrial users. Our sponsors page includes information about the organizations who have generously provided support for the Haskell Foundation.
+    The Haskell Foundation was founded by members of the Haskell community, with help and input from existing Haskell users, committees, and industrial users. Our sponsors page includes information about the organizations who have generously provided support for the Haskell Foundation.
 
     ### What is the relationship between HF and the community, industry, etc.
 
-    The Haskell Foundation is an independent organization that was created to increase haskell adoption across industry, the open source community, and academia. Many companies who see the value in haskell have provided generous support to the haskell foundation. The haskell foundation was conceived of and created by long-time members of the haskell community.
+    The Haskell Foundation is an independent organization that was created to increase Haskell adoption across industry, the open source community, and academia. Many companies who see the value in Haskell have provided generous support to the Haskell Foundation. The Haskell Foundation was conceived of and created by long-time members of the Haskell community.
 
 ---    

--- a/resources/content/pages/news/news-en.md
+++ b/resources/content/pages/news/news-en.md
@@ -9,7 +9,10 @@ news_content:
 
     #### 05 November, 2020
 
-    Today Simon Peyton-Jones announced the formation of The Haskell Foundation, a non-profit organization focused on increasing adoption of the Haskell programming language. Name Pending will serve as the Executive Director of the new foundation, alongside interim board members Simon Peyton-Jones, Simon Marlow, and Ed Kmett.
+    Today Simon Peyton Jones announced the formation of The Haskell Foundation, a non-profit organization focused on increasing adoption of the Haskell programming language. There is
+    an ongoing search for the Executive Director of the new foundation, who will
+    serve alongside interim board members Simon Peyton Jones, Chris Dornan, Gabriele Keller, Jasper Van der Jeugt, Simon Marlow, Ed Kmett, Stephanie Weirich, and Lennart Augustsson.
+    
     Haskell.org Committee Announces Haskell Foundation Affiliation
 
     #### 05 November, 2020

--- a/resources/content/pages/who-we-are/who-we-are-en.md
+++ b/resources/content/pages/who-we-are/who-we-are-en.md
@@ -6,17 +6,16 @@ about_content:
 
     ### Haskell Foundation Executive Director
 
-    The Board of Directors is currently seeking an Executive Directory. The
+    The Board of Directors is currently seeking an Executive Director. The
     Haskell Foundation's executive director will oversee the daily operations
     of the foundation.
 
     ### The Haskell Foundation Interim Board of Directors
 
-    The Haskell Foundation board of directors is a group of individuals who are
+    The Haskell Foundation [board of directors](/board-of-directors) is a group of individuals who are
     responsible for managing and setting the direction of the Haskell
-    Foundation. The [board of directors](/board-of-directors) are responsible
-    for managing. The *interim board* will serve the Haskell Foundation
-    during it's initial launch phase and will manage the establishment of the
+    Foundation. The *interim board* will serve the Haskell Foundation
+    during its initial launch phase and will manage the establishment of the
     first full board.
 
     #### Members of the Interim Board of Directors
@@ -24,25 +23,25 @@ about_content:
     | ![A photo of Simon Peyton Jones](../../images/board-bio/spj.png) |
     |--|
     |**Simon Peyton Jones**|
-    |I’m a researcher at Microsoft Research in Cambridge, England. I   |
-    |started here in Sept 1998. I’m also an Honorary Professor of the  |
-    |Computing Science Department at Glasgow University, where I was a |
-    |professor during 1990-1998.                                       |
+    |Simon is a researcher at Microsoft Research in Cambridge, England.|
+    |He started there in Sept 1998. He’s also an Honorary Professor of |
+    |the Computing Science Department at Glasgow University, where he  |
+    |was a professor during 1990-1998.                                 |
     |                                                                  |
-    |I am married to Dorothy, a priest in the Church of England. We    |
-    |have six children.                                                |
+    |Simon is married to Dorothy, a priest in the Church of England.   |
+    |They have six children.                                           |
     |                                                                  |
-    |I’m interested in the design, implementation, and application of  |
-    |lazy functional languages. In practical terms, that means I spend |
-    |a most of my time on the design and implementation of the         |
-    |language Haskell. In particular, much of my work is focused       |
+    |Simon is interested in the design, implementation, and application|
+    |of lazy functional languages. In practical terms, that means he   |
+    |spends a most of my time on the design and implementation of the  |
+    |language Haskell. In particular, much of his work is focused      |
     |around the Glasgow Haskell Compiler, and its ramifications.       |
     |                                                                  |
-    |I am chair of Computing at School, the group at the epicentre of  |
-    |the reform of the national curriculum for Computing in England.   |
-    |Computer science is now a foundational subject, alongside maths   |
-    |and natural science, that every child learns from primary school  |
-    |onwards (background here).                                        |
+    |Simon is also chair of Computing at School, the group at the      |
+    |epicentre of the reform of the national curriculum for Computing  |
+    |in England. Computer science is now a foundational subject,       |
+    |alongside maths and natural science, that every child learns from |
+    |primary school onwards.                                           |
 
     | ![A photo of Chris Dornan](../../images/board-bio/Chris.Dornan.png) |
     |--|
@@ -59,16 +58,16 @@ about_content:
     | ![Gabriele Keller](../../images/board-bio/gk.png) |
     |--|
     |**Gabriele Keller**|
-    |I’m a Professor of Software Technology in the Department of       |
-    |Information and Computing Sciences. My research focuses on how    |
+    |Gabriele is Professor of Software Technology in the Department of |
+    |Information and Computing Sciences. Her research focuses on how   |
     |programming languages can be used to improve the quality of       |
     |software. Conventional software testing is very important, but    |
-    |can’t guarantee the absence of errors. We are addressing this     |
-    |problem in our research on developing and using programming       |
+    |can’t guarantee the absence of errors. She is addressing this     |
+    |problem in her research on developing and using programming       |
     |languages that are based on mathematical theory, so we can prove  |
-    |that a program will work in all scenarios. We call it             |
+    |that a program will work in all scenarios. Call it                |
     |‘correctness by construction’. The real world significance is     |
-    |obvious: it saves a lot of time and it eliminates errors so which |
+    |obvious: it saves a lot of time and it eliminates errors, so which|
     |company wouldn’t want it?                                         |
 
     | ![Jasper Van der Jeugt](../../images/board-bio/jv.png) |
@@ -83,15 +82,15 @@ about_content:
     | ![Edward Kmett](../../images/board-bio/ed.kmett.png) |
     |--|
     |**Edward Kmett**|
-    |I spent most of my adult life trying to build reusable code in    |
-    |imperative languages before realizing I was building castles in   |
-    |sand. I converted to Haskell in 2006 while searching for better   |
-    |building materials. I now chair the Haskell core libraries        |
-    |committee, collaborate with hundreds of other developers on over  |
-    |200 projects on github, and I am obsessed with finding better     |
-    |tools so that seven years from now I won’t be stuck solving the   |
-    |same problems with small variations on the same tools I was stuck |
-    |using seven years ago.                                            |
+    |Edward spent most of his adult life trying to build reusable code |
+    |in imperative languages before realizing he was building castles  |
+    |in sand. He converted to Haskell in 2006 while searching for      |
+    |better building materials. He has sinced chaired the Haskell core |
+    |libraries committee, collaborated with hundreds of other          |
+    |developers on over 200 projects on github, and is obsessed with   |
+    |finding better tools so that seven years from now we won’t be     |
+    |stuck solving the same problems with small variations on the same |
+    |tools we were stuck using seven years ago.                        |
 
     | ![Stephanie Weirich](../../images/board-bio/sw.png) |
     |--|
@@ -153,7 +152,7 @@ about_content:
     We believe that this will help us grow towards being a more open and
     welcoming community.
 
-    The following groups affiliated with the Haskell Foundation:
+    The following groups have affiliated with the Haskell Foundation:
 
      -  The [Haskell IDE Team](https://github.com/haskell/haskell-language-server)
      -  The [GHC Steering Committee](https://github.com/ghc-proposals/ghc-proposals)


### PR DESCRIPTION
## What? (required)

Small grammar fixes, etc. The biggest change is that I rephrased the bios to all be in the third person. Having a mix of first and third person was really jarring.

## Why? (optional)

The fixes make the site more professional (to me).

## How can this be tested? (optional)

Please read the edits.

--------------------------------
Beyond the changes suggested, there are a few other errors I spotted that
I don't know how to resolve:

* [ ] In the "who are we" page: Who are "The Haskell Admins"

* [ ] In the "who are we" page: "Placeholder text until the Hackage Trustees provide an official statement."

* [ ] In the "who are we" page: Placeholder text about volunteers

* [ ] The news page doesn't format headlines correctly; they look like text in the
      preceding bullet.

* [ ] The donations page just lists sponsors at the bottom, with no formatting
      or e.g. logos.

* [ ] The resources page does not include links to the resources.

* [ ] The link to the Technical Agenda (from the FAQ) points to just a Google Doc.
      Should this be a PDF hosted as part of the site? Even if not, it should
      be https://docs.google.com/document/d/1dLKbYh5HAP_FAJhUNZH8fgcLkfKhJjUBhqEwZa9n5JA/edit,
      not the drafting document currently linked to.

* [ ] We talked about changing the thumbnail on the intro video, so it's not
      just SPJ beaming. Maybe just link to youtu.be/MEmRarBL9kw, the stream
      of SPJ's announcement.