### PR TITLE
add board nominations text

### DIFF
--- a/resources/content/pages/board-nominations/board-nominations-en.md
+++ b/resources/content/pages/board-nominations/board-nominations-en.md
@@ -1,0 +1,125 @@
+---
+about_title: en (English) Nominations for the Haskell Foundation Board of Directors
+about_content:
+  about_page_title: Haskell Foundation Board Call for Nominations
+  about_page_content: |
+
+    The Haskell Foundation seeks nominations for the Foundation Board.
+
+    The Haskell Foundation is a new non-profit organisation that seeks
+    to articulate the benefits of functional programming to a broader
+    audience, to erase barriers to entry, and to support Haskell as a
+    solidly reliable basis for mission-critical applications.
+
+    ### The Foundation Board
+
+    #### Remit of the Board
+
+    The Board provides the strategic leadership for the Foundation.  More specifically
+
+    * Governance: leadership and direction - set strategy, provide guidance
+    * Staff: appoint senior members of Foundation staff
+    * Define, curate and track Foundation goals
+    * Seek out opportunities to further the goals of the Foundation
+    * Represent the Haskell community to the world: liaise with sponsors, public bodies (ACM, standards committees) etc
+    * Ensure success and long-term continuity of the Foundation
+    * Receive and review financial accounts
+
+    #### Membership
+
+    * Being a member of the Board is not an honorary post; it involves real work.  There will typically be ad-hoc or permanent working groups, on which Board members are expected to serve or chair.
+    * The Board needs to be big enough to have a breadth of expertise and representation, but small enough to be effective.  We will start with a Board of 12 members.
+    * Once appointed, board members should act in the best interests of the Foundation and the entire Haskell community; they are not appointed to represent the interests of a particular group.
+    * Members will have fixed terms, to ensure a steady turnover of members.  There is a balance here: it’s a pity to lose strong, well-qualified members too quickly.  The details remain to be settled, but will be something like: three or four year terms, but with the possibility of being renewed once, and the possibility of returning after a gap.
+    * Terms will be staggered so that a similar number of members reach the end of their term at regular intervals.  “Regular intervals” might mean annually or every two years; again there is a balance between providing a regular “way in” and the overheads of nomination, selection, and onboarding.To bootstrap this process the Interim Board may invite some members to serve for shorter initial terms.
+    * No two members should be paid employees of the same organisation
+
+    The Executive Director reports to the board, attends all board
+    meetings, but does not vote.
+
+    The initial membership of the Board will be chosen by the Interim
+    Board, based on open nominations against written criteria.  (After
+    this bootstrap process, the Board itself chooses its new members,
+    based on a similar call for nominations.)  This document is the call
+    for nominations.
+
+    #### Key Roles
+
+    * Chair (elected annually by the Foundation Board members)
+    * Treasurer
+    * Secretary
+
+    #### Transparency
+    The Board should conduct its business as transparently as
+    possible. Specifically:
+
+    * It should publish public minutes of meetings and decisions.
+    * It should be open about its finances: where money comes from, and what it is spent on.
+    * It should conduct most conversations on a publicly-readable mailing list.
+
+    In all cases there may be some aspects of the Board’s work that should
+    properly be private, e.g. relating to security, staff, or money.  The
+    Board will have to make judgements about this, but the strong default
+    is to work in public.
+
+    ### Nominations for the Board
+
+    Please submit your nomination to [nominations@haskell.foundation](mailto:nominations@haskell.foundation),
+    by **Monday 11 January 2021**.
+
+    Your nomination should be accompanied by a brief CV and a covering
+    letter that says
+
+    * How you fit the criteria below.
+    * Why you would like to be a Board member
+    * What you feel you could contribute
+
+    Please indicate whether you would consider the role of Secretary
+    (legal knowledge/experience useful) or Treasurer (financial
+    knowledge/experience useful).
+
+    These nominations will be evaluated by the [Interim
+    Board](/who-we-are), which will disband once the Foundation Board
+    is in place.  Its members are:
+
+    * Lennart Augustsson (Epic Games)
+    * Chris Dornan (IRIS Connect)
+    * Jasper van der Jeugt (haskell.org)
+    * Gabriele Keller (Utrecht University)
+    * Ed Kmett (Miri)
+    * Simon Marlow (Facebook)
+    * Simon Peyton Jones (Microsoft Research)
+    * Stephanie Weirich (University of Pennsylvania)
+
+    ### Criteria
+
+    Nominations for membership of the Board will be evaluated against
+    the following criteria:
+
+    * You have a positive drive and vision for the Haskell community and ecosystem
+    * You have a track record of contribution to the Haskell community and ecosystem
+    * You are widely trusted and respected in the community.
+    * You have enough time and energy to devote to being a member of the board; it is not an honorary position!
+
+    The Interim Board will seek to appoint a Board that, collectively,
+    satisfies these criteria:
+
+    * Includes individuals with the skills, expertise and experience (e.g. technical, legal, organisational, community-building) that the Board needs.
+    * Reflects the rich diversity (e.g. of age, gender, geographical spread) that is in the Haskell community.
+    * Includes individuals who are well-equipped to reflect the priorities of Haskell’s various constituencies, including
+        - Companies that use Haskell in production, and Haskell consultancies; giving this group a stronger voice is one of the HF’s main goals.
+        - Users of Haskell.  That might include companies, but also includes the broader open-source community, hobbyists, etc.
+        - Sponsors: companies (or even individuals) who are funding the Foundation.
+        - People who build and run the infrastructure of the Haskell ecosystem: compilers, libraries, packaging and distribution, IDEs etc.
+        - Educators, including school, university, and commercial training courses.
+        - Functional programming researchers who build on and/or develop Haskell.
+
+    NB: nominations are also welcome from individuals who meet other
+    criteria but do not represent any particular constituency.
+
+    Simultaneously hitting all these criteria is nigh impossible.
+    However, each subsequent round of nominations for new Board
+    members offers a fresh chance to rectify any imbalances.
+
+
+---

--- a/resources/content/pages/news/news-en.md
+++ b/resources/content/pages/news/news-en.md
@@ -3,27 +3,20 @@ news_title: en (English) news page content
 news_content:
   news_page_title: News
   news_page_content: |
+
     ### Check us out on [Twitter](https://twitter.com/haskellfound)
 
-    Simon Peyton-Jones Announces The Haskell Foundation
+    ### 05 November, 2020
 
-    #### 05 November, 2020
+    #### Haskell Foundation Announced
 
     Today Simon Peyton-Jones announced the formation of The Haskell Foundation, a non-profit organization focused on increasing adoption of the Haskell programming language. Name Pending will serve as the Executive Director of the new foundation, alongside interim board members Simon Peyton-Jones, Simon Marlow, and Ed Kmett.
     Haskell.org Committee Announces Haskell Foundation Affiliation
 
-    #### 05 November, 2020
+    #### Haskell Foundation Board of Directors Call for Nominations
 
-    The Haskell Foundation is pleased to announce that the haskell.org committee has voted to affiliate with the Haskell Foundation.
-    Core Libraries Committee Announces Haskell Foundation Affiliation
-
-    #### 05 November, 2020
-
-    The Haskell Foundation is pleased to announce that the core libraries committee has voted to affiliate with the Haskell Foundation.
-    GHC Steering Committee Announces Haskell Foundation Affiliation
-
-    #### 05 November, 2020
-
-    The Haskell Foundation is pleased to announce that the GHC steering committee has voted to affiliate with the Haskell Foundation.
-
----    
+    Today the Haskell Foundation announces that it has opened the [call for
+    nominations for the Board of Directors](/board-nominations). Nominations
+    will remain open until January 11, 2021. The nominations will be voted on by
+    the current [Interim Board of Directors](/who-we-are).
+---

--- a/src/pages/board-nominations.js
+++ b/src/pages/board-nominations.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import Grid from '@material-ui/core/Grid'
+import Layout from '../components/Layout'
+import Page from '../components/Page'
+import BoardNominationsPageQuery from '../queries/BoardNominationsPageQuery'
+import Markdown from '@input-output-hk/front-end-core-components/components/Markdown'
+
+export default () => (
+  <BoardNominationsPageQuery
+    render={(content) => (
+      <Layout>
+        <Page title={content.about_page_title}>
+          <Grid container spacing={2}>
+            <Grid item xs={12}>
+              <Markdown source={content.about_page_content} />
+            </Grid>
+          </Grid>
+        </Page>
+      </Layout>
+    )}
+  />
+)

--- a/src/queries/BoardNominationsPageQuery.js
+++ b/src/queries/BoardNominationsPageQuery.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { StaticQuery, graphql } from 'gatsby'
+import Language from '@input-output-hk/front-end-core-components/components/Language'
+
+const BoardNominationsPageQuery = ({ render }) => (
+  <Language.Consumer>
+    {({ key: lang }) => (
+      <StaticQuery
+        query={graphql`
+          query {
+            allFile(filter:{relativePath:{glob:"content/pages/board-nominations/*.md"}}) {
+              nodes{
+                relativePath,
+                childMarkdownRemark{
+                  frontmatter {
+                    about_content {
+                      about_page_title
+                      about_page_content
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `}
+        render={({ allFile }) => {
+          const content = allFile.nodes.filter(node => node.relativePath === `content/pages/board-nominations/board-nominations-${lang}.md`).shift()
+          if (!content || !content.childMarkdownRemark) throw new Error(`No affiliates board-nominations found for language ${lang}`)
+          return render(content.childMarkdownRemark.frontmatter.about_content)
+        }}
+      />
+    )}
+  </Language.Consumer>
+)
+
+BoardNominationsPageQuery.propTypes = {
+  render: PropTypes.func.isRequired
+}
+
+export default BoardNominationsPageQuery


### PR DESCRIPTION
## What? (required)

- Adds a new page, /board-nominations, which contains the copy for the nomination for the board
- Updates to the new page to remove some notes about affiliation and to add news about the board nominations being open

## Why? (optional)

- News items were removed because they were unhelpful and made it harder to find the board nominations call
- Board nominations page was added because we need that to be public

## How can this be tested? (optional)

tested locally
