### PR TITLE
add mailing lists to contact page

### DIFF
--- a/resources/content/pages/contact/contact-en.md
+++ b/resources/content/pages/contact/contact-en.md
@@ -22,7 +22,7 @@ contact_content:
     Join HF-discuss email list. Joining this list is a great way to
     discuss and participate. All participation is expected to conform to
     the [Guidelines for Respectful
-    Communication](/guidelines-for-respectful-communication). Subscribe:
+    Communication](/guidelines-for-respectful-communication). Subscribe
     [here](https://mail.haskell.org/cgi-bin/mailman/listinfo/hf-discuss)
     and view the archives
     [here](https://mail.haskell.org/pipermail/hf-discuss/).


### PR DESCRIPTION
## What? (required)
Adds mailing lists to the contacts page

![contacts](https://user-images.githubusercontent.com/203691/98116252-a7c66e00-1e6d-11eb-8af3-ce9d6b120314.png)

