### PR TITLE
Improve links to mailing lists

### DIFF
--- a/resources/content/pages/index/index-en.md
+++ b/resources/content/pages/index/index-en.md
@@ -33,8 +33,12 @@ home_content:
     ### How to follow HF Developments
 
     * Follow us on [Twitter](https://twitter.com/haskellfound).
-    * Join the HF-announce email list. This list will have infrequent traffic announcing major news from the Haskell Foundation. It is expected that all messages will come from HF or its designees. Subscribe [here](https://mail.haskell.org/cgi-bin/mailman/listinfo/hf-announce) and view the archives [here](https://mail.haskell.org/pipermail/hf-announce/).
-     * Join HF-discuss email list. Joining this list is a great way to discuss and participate. All participation is expected to conform to the [Guidelines for Respectful Communication](/guidelines-for-respectful-communication). Subscribe: [here](https://mail.haskell.org/cgi-bin/mailman/listinfo/hf-discuss) and view the archives [here](https://mail.haskell.org/pipermail/hf-discuss/).
+    * Join the HF-announce email list. This list will have infrequent traffic announcing major news from the Haskell Foundation. It is expected that all messages will come from HF or its designees.
+        * [Subscribe to HF-announce](https://mail.haskell.org/cgi-bin/mailman/listinfo/hf-announce)
+        * View the [HF-announce archives](https://mail.haskell.org/pipermail/hf-announce/)
+     * Join HF-discuss email list. Joining this list is a great way to discuss and participate. All participation is expected to conform to the [Guidelines for Respectful Communication](/guidelines-for-respectful-communication).
+        * [Subscribe to HF-discuss](https://mail.haskell.org/cgi-bin/mailman/listinfo/hf-discuss)
+        * View the [HF-discuss archives](https://mail.haskell.org/pipermail/hf-discuss/)
 
     ### Haskell Foundation Board of Directors Call for Nominations
 


### PR DESCRIPTION
## What?

Change the formatting of the links to mailing lists

## Why?

When the link text says "here" I experience a high cognition hurdle. The cognition burden is much lower when the link text describes the linked-to resource.

## Screenshots

Sadly I can't run this project locally because of the 32-bit incompatibility reported at https://github.com/haskellfoundation/haskell.foundation/issues/42