### PR TITLE
get rid of rogue spaces in the middle of "the"

### DIFF
--- a/resources/content/pages/whitepaper/whitepaper-en.md
+++ b/resources/content/pages/whitepaper/whitepaper-en.md
@@ -59,7 +59,7 @@ about_content:
 
     #### Principles and Ethos
 
-    How ​ we pursue the goals of HF is just as important as ​ what t ​ he goals are. HF’s actions will be guided by these core principles:
+    How ​ we pursue the goals of HF is just as important as ​ what the goals are. HF’s actions will be guided by these core principles:
 
     - **Open source**. Haskell is an open source community and HF will embrace the open-source ethos wholeheartedly. HF may develop, or sponsor the development of tools and infrastructure, but it will all be open source.
     - **Empowering the community**. A major goal of HF is to augment, celebrate, and coordinate the contributions and leadership of volunteers, not to supplant or replace them.


### PR DESCRIPTION
## What? (required)

Got rid of a rogue space in the middle of "the" that I noticed while reading the whitepaper on https://haskell.foundation/whitepaper/

## Why? (optional)

Why has this change occurred if applicable?

## How can this be tested? (optional)

Describe how this change can be tested

## Screenshots (optional)

Upload some screenshots of the changes
