### PR TITLE
Remove “Board of Directors Call for Nominations” from frontpage

### DIFF
--- a/resources/content/pages/index/index-en.md
+++ b/resources/content/pages/index/index-en.md
@@ -40,13 +40,6 @@ home_content:
         * [Subscribe to HF-discuss](https://mail.haskell.org/cgi-bin/mailman/listinfo/hf-discuss)
         * View the [HF-discuss archives](https://mail.haskell.org/pipermail/hf-discuss/)
 
-    ### Haskell Foundation Board of Directors Call for Nominations
-
-    The Haskell Foundation has issued a [call for
-    nominations to the Board of Directors](/board-nominations). Nominations
-    will remain open until January 11, 2021. New Board members will be selected by
-    the interim members of the [Board of Directors](/who-we-are).
-
     ### [More News](/news)
 
 ---


### PR DESCRIPTION
since it has long expired. Likely more up-to-date news should be put here? Also https://haskell.foundation/news/ is a bit outdated… I guess this section needs to be removed or needs to get more love?